### PR TITLE
avoid error when using module for the first time 

### DIFF
--- a/share/library/mac_pkg
+++ b/share/library/mac_pkg
@@ -519,9 +519,11 @@ class Installer(object):
 
 tempdir = tempfile.gettempdir()
 extra_vars_path = path.join(tempdir, "battleschool_extra_vars.json")
-with open(extra_vars_path) as f:
-    extra_vars = json.load(f)
-
+if path.isfile(extra_vars_path):
+    with open(extra_vars_path) as f:
+        extra_vars = json.load(f)
+else:
+    extra_vars = {}
 
 def get_env(name, default, converter = None):
     if name in extra_vars:


### PR DESCRIPTION
When battle hasn't been executed the file "battleschool_extra_vars.json" does not exist. Therefore it is necessary to check the existence of this file first.
