### PR TITLE
#11 Add stub methods for 'run' to Git and Url Source types to fix error ...

### DIFF
--- a/lib/battleschool/source/git.py
+++ b/lib/battleschool/source/git.py
@@ -8,6 +8,10 @@ class Git(Source):
     """git source handler.
     """
 
+    def run(self, inventory, sshpass, sudopass):
+        playbooks = []
+        return playbooks
+
     def type(self):
         return 'git'
 

--- a/lib/battleschool/source/url.py
+++ b/lib/battleschool/source/url.py
@@ -7,6 +7,9 @@ from . import Source
 class Url(Source):
     """url source handler.
     """
+    def run(self, inventory, sshpass, sudopass):
+        playbooks = []
+        return playbooks
 
     def type(self):
         return 'url'


### PR DESCRIPTION
Ticket #11 Add stub methods for 'run' to Git and Url Source types to fix error on dummy-only playbooks.
