### PR TITLE
Support newer ansible versions.

### DIFF
--- a/bin/battle
+++ b/bin/battle
@@ -157,6 +157,9 @@ def main(args):
     if options.module_path is None:
         options.module_path = AC.DEFAULT_MODULE_PATH
 
+    if options.module_path is None:
+        options.module_path = C.DEFAULT_MODULE_PATH
+
     if C.DEFAULT_MODULE_PATH not in options.module_path:
         options.module_path = "%s:%s" % (C.DEFAULT_MODULE_PATH, options.module_path)
 


### PR DESCRIPTION
In 1.8 ansible changed the way they found the default module path, from returning a string to returning None.
This breaks battleschool, expecting ansible to return a string.

This change makes battleschool compatible with both pre and post 1.8 ansible.
