### PR TITLE
fixing dict lookup

### DIFF
--- a/lib/battleschool/printing.py
+++ b/lib/battleschool/printing.py
@@ -85,7 +85,7 @@ class BattleschoolRunnerCallbacks(DefaultRunnerCallbacks):
 
     def on_failed(self, host, res, ignore_errors=False):
         if not ignore_errors:
-            display("\tTask FAILED: %s %s" % (self.get_name(), res['msg']), color="red")
+            display("\tTask FAILED: %s %s" % (self.get_name(), res.get('msg')), color="red")
         super(BattleschoolRunnerCallbacks, self).on_failed(host, res, ignore_errors=ignore_errors)
 
     def on_ok(self, host, res):


### PR DESCRIPTION
Some error messages won't print because of an error in rendering the error message, this patch fixes the dict lookup (`res.get('msg')` instead of `res['msg']`)